### PR TITLE
Added the EspFirmwareFlasher

### DIFF
--- a/EspFirmwareFlasher/App.config
+++ b/EspFirmwareFlasher/App.config
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<appSettings>
+		<!-- ********************************** -->
+		<!-- ESP32 / ESP8266 tool configuration -->
+		<!-- ********************************** -->
+		<!-- default ESP chip type; ESP32 and ESP8266 are allowed -->
+		<!--<add key="DefaultEspChipType" value="ESP32"/>-->
+		<!-- default serial port if nothing is delivered via command line argument -->
+		<!--<add key="DefaultSerialPort" value="COM1"/>-->
+		<!-- default baudrate for the serial port if nothing is delivered via command line argument -->
+		<!--<add key="DefaultBaudRate" value="921600"/>-->
+		<!-- default flash mode if nothing is delivered via command line argument -->
+		<!-- See https://github.com/espressif/esptool#flash-modes for more details -->
+		<!--<add key="DefaultFlashMode" value="dio"/>-->
+		<!-- default flash frequency if nothing is delivered via command line argument -->
+		<!-- See https://github.com/espressif/esptool#flash-modes for more details -->
+		<!--<add key="DefaultFlashFrequency" value="40m"/>-->
+
+		<!-- ******************************* -->
+		<!-- Firmware download configuration -->
+		<!-- ******************************* -->
+		<!-- default firmware type -->
+		<!--<add key="DefaultFirmwareType" value="nanoClr"/>-->
+		<!-- default download location on bintray.com -->
+		<!--<add key="DefaultDownloadSource" value="https://bintray.com/nfbot/nanoframework-images-dev"/>-->
+		<!-- default board type for the firmware download -->
+		<!--<add key="DefaultBoardType" value="ESP32_DEVKITC"/>-->
+	</appSettings>
+	<startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/EspFirmwareFlasher/CreateEspToolZip.targets
+++ b/EspFirmwareFlasher/CreateEspToolZip.targets
@@ -1,0 +1,44 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- Tast for creating the esptool.zip -->
+	<UsingTask
+		TaskName="CreateEspToolZip"
+		TaskFactory="CodeTaskFactory"
+		AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" >
+		<ParameterGroup />
+		<Task>
+			<Reference Include="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1\System.IO.Compression.FileSystem.dll"/>
+			<Using Namespace="System.Diagnostics"/>
+			<Using Namespace="System.IO"/>
+			<Using Namespace="System.IO.Compression"/>
+			<Code Type="Fragment" Language="cs">
+				<![CDATA[
+// don't recreate esptool.zip if it's allready there
+if (File.Exists("esptool.zip"))
+{
+	Log.LogMessage(MessageImportance.High, "The esptool.zip is already there and will not be recreated.");
+	return _Success;
+}
+
+// delete obj\esptool-python if it's already there
+Log.LogMessage(MessageImportance.High, "Creating esptool.zip ...");
+if (Directory.Exists(@"obj\esptool-python"))
+{
+	Directory.Delete(@"obj\esptool-python", true);
+}
+
+// install esptool via pip into obj\esptool-python
+Process process = Process.Start("pip", @"install --target=obj\esptool-python esptool");
+process.WaitForExit();
+
+// create a package that can run without python via PyInstaller
+process = Process.Start("pyinstaller", @"--distpath obj\esptool-python\dist --workpath obj\esptool-python\build --specpath obj\esptool-python obj\esptool-python\esptool.py");
+process.WaitForExit();
+
+// create a zip file from the package
+ZipFile.CreateFromDirectory(@"obj\esptool-python\dist\esptool", "esptool.zip");
+return _Success;
+]]>
+			</Code>
+		</Task>
+	</UsingTask>
+</Project>

--- a/EspFirmwareFlasher/EspFirmwareFlasher.csproj
+++ b/EspFirmwareFlasher/EspFirmwareFlasher.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DCF24265-C979-4573-BF3B-05BE35429DD1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>EspFirmwareFlasher</RootNamespace>
+    <AssemblyName>EspFirmwareFlasher</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EspTool.cs" />
+    <Compile Include="NanoClrFirmware.cs" />
+    <Compile Include="WifiWaterLevelGaugeFirmware.cs" />
+    <Compile Include="Firmware.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="CreateEspToolZip.targets">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="esptool.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="CreateEspToolZip.targets" />
+  <Target Name="BeforeBuild">
+    <CreateEspToolZip />
+  </Target>
+</Project>

--- a/EspFirmwareFlasher/EspFirmwareFlasher.sln
+++ b/EspFirmwareFlasher/EspFirmwareFlasher.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EspFirmwareFlasher", "EspFirmwareFlasher.csproj", "{DCF24265-C979-4573-BF3B-05BE35429DD1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DCF24265-C979-4573-BF3B-05BE35429DD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCF24265-C979-4573-BF3B-05BE35429DD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCF24265-C979-4573-BF3B-05BE35429DD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCF24265-C979-4573-BF3B-05BE35429DD1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E2AD78E4-47FA-4E0B-9A60-3CCAEDAB0863}
+	EndGlobalSection
+EndGlobal

--- a/EspFirmwareFlasher/Firmware.cs
+++ b/EspFirmwareFlasher/Firmware.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EspFirmwareFlasher
+{
+	/// <summary>
+	/// abstract base class for download / extract an ESP32 / ESP8266 firmware from the internet
+	/// </summary>
+	internal abstract class Firmware
+	{
+		/// <summary>
+		/// Gets the supported ESP chip types for this type of firmware
+		/// </summary>
+		internal abstract string[] SupportedChipTypes { get; }
+
+		/// <summary>
+		/// Gets the supported flash sizes for this type of firmware
+		/// </summary>
+		internal abstract int[] SupportedFlashSizes { get; }
+
+		/// <summary>
+		/// Download the firmware and extract it if needed
+		/// </summary>
+		/// <param name="chipType">ESP chip types</param>
+		/// <param name="flashSize">Flashsize in bytes</param>
+		/// <returns>dictionary which keys are the start addresses and the values are the complete filenames (the bin files); or null if not successfully downloaded/extracted</returns>
+		internal abstract Dictionary<int, string> DownloadAndExtract(string chipType, int flashSize);
+
+		/// <summary>
+		/// Checks if there is a firmware theoretically (not checked in the internet) available for the combination of ESP chip type and flash size
+		/// </summary>
+		/// <param name="chipType">ESP chip type</param>
+		/// <param name="flashSize">Flashsize in bytes</param>
+		/// <returns>true if firmware is available; false otherwise</returns>
+		internal bool CheckSupport(string chipType, int flashSize)
+		{
+			if (!SupportedChipTypes.Contains(chipType))
+			{
+				Console.WriteLine($"There is no firmware available for the {chipType}!{Environment.NewLine}Only the following ESP chips are supported: {string.Join(", ", SupportedChipTypes)}");
+				return false;
+			}
+			if (!SupportedFlashSizes.Contains(flashSize))
+			{
+				string humanReadable = flashSize >= 0x10000 ? $"{flashSize / 0x10000} MB" : $"{flashSize / 0x400} KB";
+				Console.WriteLine($"There is no firmware available for the {chipType} with {humanReadable} flash size!{Environment.NewLine}Only {chipType} with the following flash sizes are supported: {string.Join(", ", SupportedFlashSizes.Select(size => size >= 0x10000 ? $"{size / 0x10000} MB" : $"{size / 0x400} KB"))}");
+				return false;
+			}
+			return true;
+		}
+	}
+}

--- a/EspFirmwareFlasher/NanoClrFirmware.cs
+++ b/EspFirmwareFlasher/NanoClrFirmware.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace EspFirmwareFlasher
+{
+	/// <summary>
+	/// Class handles the download of the ESP32 nanoCLR firmware from bintray.com
+	/// </summary>
+	internal class NanoClrFirmware : Firmware
+	{
+		/// <summary>
+		/// Download source: currently https://bintray.com/nfbot/nanoframework-images-dev
+		/// </summary>
+		private readonly string _downloadSource;
+
+		/// <summary>
+		/// Board type: currently ESP32_DEVKITC
+		/// </summary>
+		private readonly string _boardType;
+
+		/// <summary>
+		/// The directory where the firmware was unzipped
+		/// </summary>
+		private DirectoryInfo _firmwareDirectory = null;
+
+		/// <summary>
+		/// The nanoCLR is only for the ESP32
+		/// </summary>
+		internal override string[] SupportedChipTypes { get { return new string[] { "ESP32" }; } }
+
+		/// <summary>
+		/// The nanoCLR is only for 2MB and 4MB flash sizes
+		/// </summary>
+		internal override int[] SupportedFlashSizes { get { return new int[] { 0x200000, 0x400000 }; } }
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="downloadSource">Download source: currently https://bintray.com/nfbot/nanoframework-images-dev </param>
+		/// <param name="boardType">Board type: currently ESP32_DEVKITC</param>
+		internal NanoClrFirmware(string downloadSource, string boardType)
+		{
+			_downloadSource = downloadSource;
+			_boardType = boardType;
+		}
+
+		/// <summary>
+		/// Download the firmware zip, extract this zip file, and get the firmware parts
+		/// </summary>
+		/// <param name="chipType">Only ESP32 is allowed</param>
+		/// <param name="flashSize">Flashsize in bytes: Only 0x200000 (2MB) and 0x400000 (4MB) is allowed</param>
+		/// <returns>a dictionary which keys are the start addresses and the values are the complete filenames (the bin files)</returns>
+		internal override Dictionary<int, string> DownloadAndExtract(string chipType, int flashSize)
+		{
+			// check if chip type / flash size is supported
+			if (!CheckSupport(chipType, flashSize))
+			{
+				return null;
+			}
+
+			// find out what the latest version is; that's written at the overview page
+			WebClient webClient = new WebClient();
+			string latestVersionPage = webClient.DownloadString(string.Join("/", _downloadSource, _boardType, "_latestVersion"));
+
+			// find the filename
+			Match match = Regex.Match(latestVersionPage, $"(/{_boardType}/)(?<filename>[\\d]+[^\"'/]*)");
+			if (!match.Success)
+			{
+				Console.WriteLine($"Can't find the latest firmware version on {_downloadSource}!");
+				return null;
+			}
+			string filename = match.Groups["filename"].ToString().Trim();
+			string filenameWithExtension = string.Concat(filename, ".zip");
+			if (File.Exists(filenameWithExtension))
+			{
+				File.Delete(filenameWithExtension);
+			}
+			
+			// download the firmware file
+			webClient.DownloadFile(string.Join("/", _downloadSource, $"download_file?file_path={_boardType}-{filenameWithExtension}"), filenameWithExtension);
+
+			// delete directory if already exists
+			_firmwareDirectory = new DirectoryInfo(filename);
+			if (_firmwareDirectory.Exists)
+			{
+				_firmwareDirectory.Delete(true);
+			}
+
+			// unzip the firmware
+			Console.WriteLine($"Extracting {filenameWithExtension} ...");
+			ZipFile.ExtractToDirectory(filenameWithExtension, _firmwareDirectory.FullName);
+
+			// Get the parts that should be written to ESP32 flash
+			Dictionary<int, string> partsToFlash = new Dictionary<int, string>();
+			// bootloader goes to 0x1000
+			partsToFlash.Add(0x1000, Path.Combine(_firmwareDirectory.FullName, "bootloader.bin"));
+			// nanoCLR goes to 0x10000
+			partsToFlash.Add(0x10000, Path.Combine(_firmwareDirectory.FullName, "NanoCLR.bin"));
+			// partition table goes to 0x8000; there is on partition tabel for 2MB flash and one for 4MB flash
+			partsToFlash.Add(0x8000, Path.Combine(_firmwareDirectory.FullName, flashSize == 0x200000 ? "partitions_2mb.bin" : "partitions_4mb.bin"));
+			return partsToFlash;
+		}
+	}
+}

--- a/EspFirmwareFlasher/Program.cs
+++ b/EspFirmwareFlasher/Program.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+
+namespace EspFirmwareFlasher
+{
+	/// <summary>
+	/// Main class
+	/// </summary>
+	internal class Program
+	{
+		/// <summary>
+		/// Entry point
+		/// </summary>
+		/// <param name="args">You can deliver the following arguments as name=value pairs:
+		/// --help or -h for a description which command line parameters can be used.
+		/// --port or -p for the serial port to use (e.g. --port=COM1).
+		/// --baud or -b for the baud rate to use for the serial port (e.g. --baud=921600).
+		/// --chip or -c for the connected ESP chip type (e.g. --chip=ESP32). Only ESP32 and ESP8266 are allowed.
+		/// --flash_mode or -fm for the flash mode to use (e.g. --flash_mode=dio). See https://github.com/espressif/esptool#flash-modes for more details.
+		/// --flash_freq or -ff for the flash frequency to use (e.g. --flash_freq=40m). See https://github.com/espressif/esptool#flash-modes for more details.
+		/// </param>
+		/// <remarks>
+		/// If no arguments are delivered the tool asks for the serial port at the command line. Then it uses the baudrate 921600, the flash mode "dio" and the flash frequency "40m".
+		/// You can set other default values via NanoClrEsp32Flasher.exe.config (application configuration) file.
+		/// </remarks>
+		/// <returns>0: successful executed; no error;
+		/// -1: an internal exception occured
+		/// -2: couldn't connect to the ESP chip or couldn't retrive the infos from the ESP chip
+		/// -3: ESP chip has an unexpected flash size; e.g. only 2MB and 4MB flash sizes are supported for the nanoCLR
+		/// -4: The firmware couldn't downloaded
+		/// -5: Error during flash erase
+		/// -6: Error during writing to flash
+		/// </returns>
+		private static int Main(string[] args)
+		{
+			try
+			{
+				string serialPort = null;
+				int baudRate = 921600;
+				string chipType = "ESP32";
+				string flashMode = "dio";
+				int flashFrequency = 40000000;
+				string firmwareType = "nanoCLR";
+				string downloadSource = "https://bintray.com/nfbot/nanoframework-images-dev";
+				string boardType = "ESP32_DEVKITC";
+				bool showHelp = false;
+
+				Console.WriteLine($"ESP Firmware Flash Tool - {typeof(Program).Assembly.GetName().Version.ToString(3)}");
+
+				// configure from application settings
+				string setting = ConfigurationManager.AppSettings.Get("DefaultSerialPort");
+				if (!string.IsNullOrEmpty(setting))
+				{
+					serialPort = setting;
+				}
+				setting = ConfigurationManager.AppSettings.Get("DefaultBaudRate");
+				if (!string.IsNullOrEmpty(setting))
+				{
+					baudRate = Convert.ToInt32(setting);
+				}
+				setting = ConfigurationManager.AppSettings.Get("DefaultEspChipType");
+				if (!string.IsNullOrEmpty(setting))
+				{
+					chipType = setting;
+				}
+				setting = ConfigurationManager.AppSettings.Get("DefaultFlashMode");
+				if (!string.IsNullOrEmpty(setting))
+				{
+					flashMode = setting;
+				}
+				setting = ConfigurationManager.AppSettings.Get("DefaultFlashFrequency");
+				if (!string.IsNullOrEmpty(setting))
+				{
+					flashFrequency = setting.ToUpperInvariant().EndsWith("M") ? Convert.ToInt32(setting.Substring(0, setting.Length - 1)) * 1000000 : Convert.ToInt32(setting);
+				}
+				setting = ConfigurationManager.AppSettings.Get("DefaultFirmwareType");
+				if (!string.IsNullOrEmpty(setting))
+				{
+					firmwareType = setting;
+				}
+				setting = ConfigurationManager.AppSettings.Get("DefaultDownloadSource");
+				if (!string.IsNullOrEmpty(setting))
+				{
+					downloadSource = setting;
+				}
+				setting = ConfigurationManager.AppSettings.Get("DefaultBoardType");
+				if (!string.IsNullOrEmpty(setting))
+				{
+					boardType = setting;
+				}
+
+				// parse command line
+				if (args != null || args.Length > 0)
+				{
+					foreach (string arg in args)
+					{
+						if (arg == "--help" || arg == "-h")
+						{
+							showHelp = true;
+							break;
+						}
+
+						string[] parts = arg.Split('=');
+						if (parts.Length != 2)
+						{
+							continue;
+						}
+						switch (parts[0].Trim())
+						{
+							case "--port":
+							case "-p":
+								serialPort = parts[1].Trim();
+								break;
+							case "--baud":
+							case "-b":
+								baudRate = Convert.ToInt32(parts[1].Trim());
+								break;
+							case "--chip":
+							case "-c":
+								chipType = parts[1].Trim();
+								break;
+							case "--flash_mode":
+							case "-fm":
+								flashMode = setting.Trim();
+								break;
+							case "--flash_freq":
+							case "-ff":
+								string trimmed = parts[1].Trim();
+								flashFrequency = trimmed.ToUpperInvariant().EndsWith("M") ? Convert.ToInt32(trimmed.Substring(0, trimmed.Length - 1)) * 1000000 : Convert.ToInt32(trimmed);
+								break;
+						}
+					}
+				}
+
+				if (showHelp)
+				{
+					Console.WriteLine();
+					Console.WriteLine("You can deliver the following arguments as name = value pairs:");
+					Console.WriteLine("--help or -h for a description which command line parameters can be used.");
+					Console.WriteLine("--port or -p for the serial port to use (e.g. --port=COM1).");
+					Console.WriteLine("--baud or -b for the baud rate to use for the serial port (e.g. --baud=921600).");
+					Console.WriteLine("--chip or -c for the connected ESP chip type (e.g. --chip=ESP32). Only ESP32 and ESP8266 are allowed.");
+					Console.WriteLine("--flash_mode or -fm for the flash mode to use (e.g. --flash_mode=dio). See https://github.com/espressif/esptool#flash-modes for more details.");
+					Console.WriteLine("--flash_freq or -ff for the flash frequency to use (e.g. --flash_freq=40m). See https://github.com/espressif/esptool#flash-modes for more details.");
+					Console.WriteLine();
+					Console.WriteLine("If no arguments are delivered the tool asks for the serial port at the command line. Then it uses the baudrate 921600, the flash mode \"dio\" and the flash frequency \"40m\".");
+					Console.WriteLine("You can set other default values via NanoClrEsp32Flasher.exe.config (application configuration) file.");
+					Console.WriteLine();
+					Console.WriteLine("The tool delivers the following exit codes:");
+					Console.WriteLine("0: successful executed; no error");
+					Console.WriteLine("-1: An internal exception occured");
+					Console.WriteLine("-2: Couldn't connect to the ESP chip or couldn't retrive the infos from the ESP chip");
+					Console.WriteLine("-3: ESP chip has an unexpected flash size; e.g. only 2MB and 4MB flash sizes are supported for the nanoCLR");
+					Console.WriteLine("-4: The firmware couldn't downloaded");
+					Console.WriteLine("-5: Error during flash erase");
+					Console.WriteLine("-6: Error during writing to flash");
+					return 0;
+				}
+
+				// determine the serial port
+				if (serialPort == null)
+				{
+					Console.WriteLine($"At which serial port is an {chipType} module waiting in download mode? (e.g. COM1)");
+					serialPort = Console.ReadLine();
+				}
+
+				// print out the used parameters
+				Console.WriteLine($"Using {serialPort} with {baudRate} baud for connecting to an {chipType}.");
+				Console.WriteLine($"Flashing will be done with mode {flashMode} at {flashFrequency / 1000000} MHz.");
+				Console.WriteLine($"{firmwareType} firmware will be downloaded from: {downloadSource}");
+
+				// get alle availabe info form esptool; this tests the connection to the chip
+				Console.WriteLine($"Trying to connect and getting infos about the {chipType} chip ...");
+				EspTool espTool = new EspTool(serialPort, baudRate, chipType, flashMode, flashFrequency);
+				EspTool.Info? info = espTool.TestChip();
+				if (!info.HasValue)
+				{
+					return -2;
+				}
+
+				Firmware firmware = null;
+				if (firmwareType == "nanoCLR")
+				{
+					// download nanoCLR firmware from bintray.com
+					Console.WriteLine($"Downloading {boardType} nanoCLR firmware from {downloadSource} ...");
+					firmware = new NanoClrFirmware(downloadSource, boardType);
+				}
+				else if (firmwareType == "WifiWaterLevelGauge")
+				{
+					// download WifiWaterLevelGauge firmware from github.com
+					Console.WriteLine($"Downloading WifiWaterLevelGauge firmware from {downloadSource} ...");
+					firmware = new WifiWaterLevelGaugeFirmware(downloadSource);
+				}
+				if (firmware == null || !firmware.CheckSupport(chipType, info.Value.FlashSize))
+				{
+					return -3;
+				}
+				Dictionary<int, string> firmwareParts = firmware.DownloadAndExtract(chipType, info.Value.FlashSize);
+				if (firmwareParts == null)
+				{
+					return -4;
+				}
+
+				// erase flash
+				Console.WriteLine($"Erasing flash ...");
+				if (!espTool.EraseFlash())
+				{
+					return -5;
+				}
+
+				// write to flash
+				Console.WriteLine($"Flashing firmware ... this can take while ...");
+				if (!espTool.WriteFlash(firmwareParts))
+				{
+					return -6;
+				}
+				Console.WriteLine("Successfully flashed!");
+				return 0;
+			}
+			catch (Exception exception)
+			{
+				Console.WriteLine(exception.Message);
+				Console.WriteLine(exception.StackTrace);
+				return -1;
+			}
+			finally
+			{
+				if (args == null || args.Length == 0)
+				{
+					Console.WriteLine("Press any key to exit.");
+					Console.ReadKey();
+				}
+			}
+		}
+	}
+}

--- a/EspFirmwareFlasher/Program.cs
+++ b/EspFirmwareFlasher/Program.cs
@@ -22,7 +22,7 @@ namespace EspFirmwareFlasher
 		/// </param>
 		/// <remarks>
 		/// If no arguments are delivered the tool asks for the serial port at the command line. Then it uses the baudrate 921600, the flash mode "dio" and the flash frequency "40m".
-		/// You can set other default values via NanoClrEsp32Flasher.exe.config (application configuration) file.
+		/// You can set other default values via EspFirmwareFlasher.exe.config (application configuration) file.
 		/// </remarks>
 		/// <returns>0: successful executed; no error;
 		/// -1: an internal exception occured

--- a/EspFirmwareFlasher/Properties/AssemblyInfo.cs
+++ b/EspFirmwareFlasher/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EspFirmwareFlasher")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EspFirmwareFlasher")]
+[assembly: AssemblyCopyright("Copyright © 2018 The nanoFramework project contributors")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/EspFirmwareFlasher/README.md
+++ b/EspFirmwareFlasher/README.md
@@ -1,0 +1,40 @@
+# EspFirmwareFlasher
+
+## A little command line tool that does the upload of the nanoCLR automatically
+
+### Usage
+1. Unzip it into a folder
+2. Bring your ESP32 into download mode, connect it via USB cable to your PC and find out on which serial port it is connected
+3. Start EspFirmwareFlasher.exe and enter the serial port
+4. Wait a few seconds. Your ESP32 is flashed with the latest nanoCLR firmware.
+
+### Return codes
+If the tool will be used as part of an automatic process the return code can be useful to find out what is gone wrong. Here are the known return codes:
+```
+0: successful executed; no error;
+-1: an internal exception occured
+-2: couldn't connect to the ESP chip or couldn't retrive the infos from the ESP chip
+-3: ESP chip has an unexpected flash size; e.g. only 2MB and 4MB flash sizes are supported for the nanoCLR
+-4: The firmware couldn't downloaded
+-5: Error during flash erase
+-6: Error during writing to flash
+```
+
+### What it does
+1. Extract the esptool.zip (that's the original esptool.py packaged with pyinstaller)
+2. Connect via esptool to the ESP32 and find out information about the connected chip
+3. Download the latest firmware from https://bintray.com/nfbot/nanoframework-images-dev and unzip it
+4. Erase the entire flash
+5. Write the bootloader, nanoCLR and partitionTable into the ESP32 flash
+
+### Optional configuration
+You can deliver the following command line arguments as name=value pairs:
+```
+--help or -h for a description which command line parameters can be used.
+--port or -p for the serial port to use (e.g. --port=COM1).
+--baud or -b for the baud rate to use for the serial port (e.g. --baud=921600).
+--chip or -c for the connected ESP chip type (e.g. --chip=ESP32). Only ESP32 and ESP8266 are allowed.
+--flash_mode or -fm for the flash mode to use (e.g. --flash_mode=dio). See https://github.com/espressif/esptool#flash-modes for more details.
+--flash_freq or -ff for the flash frequency to use (e.g. --flash_freq=40m). See https://github.com/espressif/esptool#flash-modes for more details.
+```
+If no arguments are delivered the tool asks for the serial port at the command line. Then it uses the baudrate 921600, the flash mode "dio" and the flash frequency "40m". You can set other default values via EspFirmwareFlasher.exe.config (application configuration) file.

--- a/EspFirmwareFlasher/WifiWaterLevelGaugeFirmware.cs
+++ b/EspFirmwareFlasher/WifiWaterLevelGaugeFirmware.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace EspFirmwareFlasher
+{
+	/// <summary>
+	/// Class handles the download of the ESP8266 WifiWaterLevelGauge firmware from github.com
+	/// </summary>
+	internal class WifiWaterLevelGaugeFirmware : Firmware
+	{
+		/// <summary>
+		/// Download source: currently https://github.com/MatthiasJentsch/WifiWaterLevelGauge
+		/// </summary>
+		private readonly string _downloadSource;
+
+		/// <summary>
+		/// The directory where the firmware was unzipped
+		/// </summary>
+		private DirectoryInfo _firmwareDirectory = null;
+
+		/// <summary>
+		/// The WifiWaterLevelGauge is only for the ESP8266
+		/// </summary>
+		internal override string[] SupportedChipTypes { get { return new string[] { "ESP8266" }; } }
+
+		/// <summary>
+		/// The WifiWaterLevelGauge is only for 512KB flash size
+		/// </summary>
+		internal override int[] SupportedFlashSizes { get { return new int[] { 0x8000 }; } }
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="downloadSource">Download source: currently https://github.com/MatthiasJentsch/WifiWaterLevelGauge </param>
+		internal WifiWaterLevelGaugeFirmware(string downloadSource)
+		{
+			_downloadSource = downloadSource;
+		}
+
+		/// <summary>
+		/// Download the firmware and get the firmware parts
+		/// </summary>
+		/// <param name="chipType">Only ESP8266 is allowed</param>
+		/// <param name="flashSize">Flashsize in bytes: Only 0x8000 (512KB) is allowed</param>
+		/// <returns>a dictionary which keys are the start addresses and the values are the complete filenames (the bin files)</returns>
+		internal override Dictionary<int, string> DownloadAndExtract(string chipType, int flashSize)
+		{
+			// check if chip type / flash size is supported
+			if (!CheckSupport(chipType, flashSize))
+			{
+				return null;
+			}
+
+			// delete the destination directory if exists
+			_firmwareDirectory = new DirectoryInfo("WifiWaterLevelGauge");
+			if (_firmwareDirectory.Exists)
+			{
+				_firmwareDirectory.Delete(true);
+			}
+			_firmwareDirectory.Create();
+
+			// load the page with the latest release
+			WebClient webClient = new WebClient();
+			string latestVersionPage = webClient.DownloadString(string.Join("/", _downloadSource, "releases/latest"));
+
+			// find the download links and the filenames; search for all links
+			// regex found at: https://stackoverflow.com/questions/15926142/regular-expression-for-finding-href-value-of-a-a-link
+			MatchCollection matches = Regex.Matches(latestVersionPage, @"<a\s+(?:[^>]*?\s+)?href=([""'])(.*?)\1");
+			if (matches.Count == 0)
+			{
+				Console.WriteLine($"Can't find the latest firmware version on {_downloadSource}!");
+				return null;
+			}
+
+			// parse the links
+			string schemaAndServer = new Uri(_downloadSource).GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped);
+			string linkBootloader = null;
+			string linkFirmware = null;
+			string filenameBootloader = null;
+			string filenameFirmware = null;
+			bool found = false;
+			foreach (Match match in matches)
+			{
+				string link = match.Groups[2].ToString().Trim();
+				if (link.EndsWith(".bin"))
+				{
+					if (link.Contains("0x00000"))
+					{
+						linkBootloader = string.Concat(schemaAndServer, link);
+						filenameBootloader = Path.Combine(_firmwareDirectory.FullName, link.Substring(link.LastIndexOf('/') + 1));
+					}
+					else if (link.Contains("0x10000"))
+					{
+						linkFirmware = string.Concat(schemaAndServer, link);
+						filenameFirmware = Path.Combine(_firmwareDirectory.FullName, link.Substring(link.LastIndexOf('/') + 1));
+					}
+					if (linkBootloader != null && linkFirmware != null)
+					{
+						found = true;
+						break;
+					}
+				}
+			}
+
+			// found both links?
+			if (!found)
+			{
+				Console.WriteLine($"Can't find the latest firmware version on {_downloadSource}!");
+				return null;
+			}
+			
+			// download the firmware files
+			webClient.DownloadFile(linkBootloader, filenameBootloader);
+			webClient.DownloadFile(linkFirmware, filenameFirmware);
+
+			Dictionary<int, string> partsToFlash = new Dictionary<int, string>();
+			// bootloader goes to 0x00000
+			partsToFlash.Add(0x00000, filenameBootloader);
+			// firmware goes to 0x10000
+			partsToFlash.Add(0x10000, filenameFirmware);
+			return partsToFlash;
+		}
+	}
+}


### PR DESCRIPTION
# EspFirmwareFlasher

## A little command line tool that does the upload of the nanoCLR automatically

### Usage
1. Unzip it into a folder
2. Bring your ESP32 into download mode, connect it via USB cable to your PC and find out on which serial port it is connected
3. Start EspFirmwareFlasher.exe and enter the serial port
4. Wait a few seconds. Your ESP32 is flashed with the latest nanoCLR firmware.

### Return codes
If the tool will be used as part of an automatic process the return code can be useful to find out what is gone wrong. Here are the known return codes:
```
0: successful executed; no error;
-1: an internal exception occured
-2: couldn't connect to the ESP chip or couldn't retrive the infos from the ESP chip
-3: ESP chip has an unexpected flash size; e.g. only 2MB and 4MB flash sizes are supported for the nanoCLR
-4: The firmware couldn't downloaded
-5: Error during flash erase
-6: Error during writing to flash
```

### What it does
1. Extract the esptool.zip (that's the original esptool.py packaged with pyinstaller)
2. Connect via esptool to the ESP32 and find out information about the connected chip
3. Download the latest firmware from https://bintray.com/nfbot/nanoframework-images-dev and unzip it
4. Erase the entire flash
5. Write the bootloader, nanoCLR and partitionTable into the ESP32 flash

### Optional configuration
You can deliver the following command line arguments as name=value pairs:
```
--help or -h for a description which command line parameters can be used.
--port or -p for the serial port to use (e.g. --port=COM1).
--baud or -b for the baud rate to use for the serial port (e.g. --baud=921600).
--chip or -c for the connected ESP chip type (e.g. --chip=ESP32). Only ESP32 and ESP8266 are allowed.
--flash_mode or -fm for the flash mode to use (e.g. --flash_mode=dio). See https://github.com/espressif/esptool#flash-modes for more details.
--flash_freq or -ff for the flash frequency to use (e.g. --flash_freq=40m). See https://github.com/espressif/esptool#flash-modes for more details.
```
If no arguments are delivered the tool asks for the serial port at the command line. Then it uses the baudrate 921600, the flash mode "dio" and the flash frequency "40m". You can set other default values via EspFirmwareFlasher.exe.config (application configuration) file.