### PR TITLE
Made EspFirmwareFlasher compatible with ESP32-PICO-D4 module

### DIFF
--- a/EspFirmwareFlasher/EspTool.cs
+++ b/EspFirmwareFlasher/EspTool.cs
@@ -201,7 +201,7 @@ namespace EspFirmwareFlasher
 			Console.WriteLine($"Found {name} with MAC address {mac} and features {features}");
 			
 			// execute flash_id command and parse the result
-			if (!RunEspTool("flash_id", true, false, null, out messages))
+			if (!RunEspTool("flash_id", false, false, null, out messages))
 			{
 				Console.WriteLine(messages);
 				return null;

--- a/EspFirmwareFlasher/Properties/AssemblyInfo.cs
+++ b/EspFirmwareFlasher/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]


### PR DESCRIPTION
For command flash_id the option --no-stub was removed, because it was not working with ESP32-PICO-D4 module

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>