### PR TITLE
Improve alpha build stamp.

### DIFF
--- a/azure-pipelines-templates/class-lib-build-only.yml
+++ b/azure-pipelines-templates/class-lib-build-only.yml
@@ -107,7 +107,7 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pr#" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pr" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
           }
           if ($env:System_PullRequest_SourceBranch -like 'release*')
           {

--- a/azure-pipelines-templates/class-lib-build-only.yml
+++ b/azure-pipelines-templates/class-lib-build-only.yml
@@ -107,7 +107,7 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha"
+            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pull_request" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
           }
           if ($env:System_PullRequest_SourceBranch -like 'release*')
           {

--- a/azure-pipelines-templates/class-lib-build-only.yml
+++ b/azure-pipelines-templates/class-lib-build-only.yml
@@ -107,7 +107,7 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pull_request" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pr#" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
           }
           if ($env:System_PullRequest_SourceBranch -like 'release*')
           {

--- a/azure-pipelines-templates/class-lib-build.yml
+++ b/azure-pipelines-templates/class-lib-build.yml
@@ -108,7 +108,7 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pull_request" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pr#" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
           }
 
           if ($env:System_PullRequest_SourceBranch -like 'release*')

--- a/azure-pipelines-templates/class-lib-build.yml
+++ b/azure-pipelines-templates/class-lib-build.yml
@@ -108,7 +108,7 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha"
+            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pull_request" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
           }
 
           if ($env:System_PullRequest_SourceBranch -like 'release*')

--- a/azure-pipelines-templates/class-lib-build.yml
+++ b/azure-pipelines-templates/class-lib-build.yml
@@ -108,7 +108,7 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pr#" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pr" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
           }
 
           if ($env:System_PullRequest_SourceBranch -like 'release*')


### PR DESCRIPTION
## Description
Improve alpha build stamp to indicate to users it is from a PR.

## Motivation and Context
Given that there might be confusion for consumers of the nuget packages, it is best to say that they are part of a PR (with its number).
- Fixes/Closes/Resolves nanoFramework/Home#NNNN

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
