### PR TITLE
Fix string replace when handling PR build.

### DIFF
--- a/azure-pipelines-templates/class-lib-build-only.yml
+++ b/azure-pipelines-templates/class-lib-build-only.yml
@@ -107,7 +107,8 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pr" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $alphaPrString = "alpha-pr" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $MyNuGetVersion = $MyNuGetVersion -replace "preview", $alphaPrString
           }
           if ($env:System_PullRequest_SourceBranch -like 'release*')
           {

--- a/azure-pipelines-templates/class-lib-build.yml
+++ b/azure-pipelines-templates/class-lib-build.yml
@@ -108,7 +108,8 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $MyNuGetVersion = $MyNuGetVersion -replace "preview", "alpha-pr" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $alphaPrString = "alpha-pr" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $MyNuGetVersion = $MyNuGetVersion -replace "preview", $alphaPrString
           }
 
           if ($env:System_PullRequest_SourceBranch -like 'release*')


### PR DESCRIPTION
## Description
The right side of string replace was being interpreted as multiple parameters rather than just 1.

## Motivation and Context
- #19 broke the build for class libs.

## How Has This Been Tested?
Tested as far as possible in ISE

## Screenshots

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
