### PR TITLE
Use PR Number rather than ID

### DIFF
--- a/azure-pipelines-templates/class-lib-build-only.yml
+++ b/azure-pipelines-templates/class-lib-build-only.yml
@@ -107,7 +107,7 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $alphaPrString = "alpha-pr" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $alphaPrString = "alpha-pr" + $env:System_PullRequest_PullRequestNumber + "." + $env:NBGV_VersionHeight
             $MyNuGetVersion = $MyNuGetVersion -replace "preview", $alphaPrString
           }
           if ($env:System_PullRequest_SourceBranch -like 'release*')

--- a/azure-pipelines-templates/class-lib-build.yml
+++ b/azure-pipelines-templates/class-lib-build.yml
@@ -108,7 +108,7 @@ steps:
           # replace preview with alpha if this is a PR build
           if($env:System_PullRequest_PullRequestId -ne $null)
           {
-            $alphaPrString = "alpha-pr" + $env:System_PullRequest_PullRequestId + "." + $env:NBGV_VersionHeight
+            $alphaPrString = "alpha-pr" + $env:System_PullRequest_PullRequestNumber + "." + $env:NBGV_VersionHeight
             $MyNuGetVersion = $MyNuGetVersion -replace "preview", $alphaPrString
           }
 


### PR DESCRIPTION
## Description
Because are PR's are generated in GitHub (rather than Azure) The ID does not display the information correctly.

## Motivation and Context
Makes it easier for a user to identify the correct PR.
- Fixes/Closes/Resolves nanoFramework/Home#NNNN

## How Has This Been Tested?<!-- (if applicable) -->


## Screenshots<!-- (if appropriate): -->
![image](https://user-images.githubusercontent.com/11439699/103214338-1244d900-4908-11eb-9165-57ef7d2c76d8.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
