### PR TITLE
Add parameter for nuget release type

### DIFF
--- a/github-actions/update-nf-dependencies.ps1
+++ b/github-actions/update-nf-dependencies.ps1
@@ -6,6 +6,27 @@
 ######################################
 # this is building from github actions
 
+param ($nugetReleaseType)
+
+if ([string]::IsNullOrEmpty($nugetReleaseType))
+{
+    if('${{ github.ref }}' -like '*release*' -or '${{ github.ref }}' -like '*master*' -or '${{ github.ref }}' -like '*main*' -or '${{ github.ref }}' -like '*stable*')
+    {
+        $nugetReleaseType = "stable"
+    }
+    else
+    {
+        $nugetReleaseType = "prerelease"
+    }
+}
+else
+{
+    if(!$nugetReleaseType -like '*stable*' -or !$nugetReleaseType -like '*prerelease*' )
+    {
+        $nugetReleaseType = "stable"
+    }
+}
+
 # get repository name from the repo path
 Set-Location ".." | Out-Null
 $library = Split-Path $(Get-Location) -Leaf
@@ -128,7 +149,7 @@ foreach ($solutionFile in $solutionFiles)
 
                 "Updating package $packageName" | Write-Host
 
-                if ('${{ github.ref }}' -like '*release*' -or '${{ github.ref }}' -like '*master*' -or '${{ github.ref }}' -like '*main*' -or '${{ github.ref }}' -like '*stable*')
+                if ($nugetReleaseType -like '*stable*')
                 {
                     # don't allow prerelease for release and master branches
 

--- a/github-actions/update-nf-dependencies.ps1
+++ b/github-actions/update-nf-dependencies.ps1
@@ -21,7 +21,7 @@ if ([string]::IsNullOrEmpty($nugetReleaseType))
 }
 else
 {
-    if(!$nugetReleaseType -like '*stable*' -or !$nugetReleaseType -like '*prerelease*' )
+    if($nugetReleaseType -notlike '*stable*' -or $nugetReleaseType -notlike '*prerelease*' )
     {
         $nugetReleaseType = "stable"
     }


### PR DESCRIPTION
## Description
In certain circumstances, it is advantageous to target a specific nuget release type that is different to the branch type.

## Motivation and Context
Useful for Samples repo, and other users forks etc.

## How Has This Been Tested?

## Screenshots

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
