### PR TITLE
Adds a powershell script for building nf lib/program with github actions workflow

### DIFF
--- a/github-actions/install-nf-build-components.ps1
+++ b/github-actions/install-nf-build-components.ps1
@@ -1,0 +1,47 @@
+[System.Net.WebClient]$webClient = New-Object System.Net.WebClient
+$webClient.UseDefaultCredentials = $true
+
+function DownloadVsixFile($fileUrl, $downloadFileName)
+{
+    Write-Host "Download VSIX file from $fileUrl to $downloadFileName"
+    $webClient.DownloadFile($fileUrl,$downloadFileName)
+}
+
+"Downloaded extension" | Write-Host
+
+$tempDir = $Env:RUNNER_TEMP
+
+# Get extension information from VSIX Gallery feed
+$vsixFeedXml = Join-Path -Path $tempDir -ChildPath "vs-extension-feed.xml"
+$webClient.DownloadFile("http://vsixgallery.com/feed/author/nanoframework", $vsixFeedXml)
+[xml]$feedDetails = Get-Content $vsixFeedXml
+
+# Find which VS version is installed
+$VsWherePath = "${env:PROGRAMFILES(X86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+
+Write-Output "VsWherePath is: $VsWherePath"
+
+$VsInstance = $(&$VSWherePath -latest -property displayName)
+
+$idVS2019 = 1
+#$idVS2017 = 0
+
+$extensionUrl = $feedDetails.feed.entry[$idVS2019].content.src
+$vsixPath = Join-Path -Path $tempDir -ChildPath "nf-extension.zip"
+$extensionVersion = $feedDetails.feed.entry[$idVS2019].Vsix.Version
+
+# Download VS extension
+DownloadVsixFile $extensionUrl $vsixPath
+
+# unzip extension
+Write-Host "Unzip extension content"
+Expand-Archive -LiteralPath $vsixPath -DestinationPath $tempDir\nf-extension\ | Write-Host
+
+# Copy build files to msbuild location
+$VsPath = $(&$VsWherePath -latest -property installationPath)
+
+Write-Host "Copy build files to msbuild location"
+$msbuildPath = Join-Path -Path $VsPath -ChildPath "\MSBuild"
+Copy-Item -Path "$tempDir\nf-extension\`$MSBuild\nanoFramework" -Destination $msbuildPath -Recurse
+
+Write-Host "Installed VS extension v$extensionVersion"


### PR DESCRIPTION
## Description
Adds a powershell script for installing the necessary build components for use with github actions workflow

## Motivation and Context
Currently it is not easy to build an independent lib or program using the GitHub actions workflow. This is a first step to that goal.

It can be called using something like this:

```
      - name: Checkout tools repo
        uses: actions/checkout@v2
        with:
          repository: nanoframework/nf-tools
          path: tools
      - name: Install build components for nanoFramework
        run: ./github-actions/install-nf-build-components.ps1
        working-directory: tools
```

## How Has This Been Tested?<!-- (if applicable) -->
from a fork of this repo, and a new peripheral driver repo.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
