### PR TITLE
Adds a flag to override file when there is a conflict.

### DIFF
--- a/github-actions/update-nf-dependencies.ps1
+++ b/github-actions/update-nf-dependencies.ps1
@@ -172,11 +172,11 @@ foreach ($solutionFile in $solutionFiles)
 
                     if (![string]::IsNullOrEmpty($nugetConfig))
                     {
-                        nuget update $solutionFile.FullName -Id "$packageName" -ConfigFile $nugetConfig
+                        nuget update $solutionFile.FullName -Id "$packageName" -ConfigFile $nugetConfig -FileConflictAction Overwrite
                     }
                     else
                     {
-                        nuget update $solutionFile.FullName -Id "$packageName"
+                        nuget update $solutionFile.FullName -Id "$packageName" -FileConflictAction Overwrite
                     }
 
                 }
@@ -185,11 +185,11 @@ foreach ($solutionFile in $solutionFiles)
 
                     if (![string]::IsNullOrEmpty($nugetConfig))
                     {
-                        nuget update $solutionFile.FullName -Id "$packageName" -ConfigFile $nugetConfig -PreRelease
+                        nuget update $solutionFile.FullName -Id "$packageName" -ConfigFile $nugetConfig -PreRelease -FileConflictAction Overwrite
                     }
                     else
                     {
-                        nuget update $solutionFile.FullName -Id "$packageName" -PreRelease
+                        nuget update $solutionFile.FullName -Id "$packageName" -PreRelease -FileConflictAction Overwrite
                     }
                 }
 


### PR DESCRIPTION
## Description
Adds a flag to override file when there is a conflict (rather than prompt)

## Motivation and Context
Required for test framework nuget as the runsettings file may already exist.

## How Has This Been Tested?<!-- (if applicable) -->
On a fork with out of date test framework package.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
