### PR TITLE
Fix checks for branch names & PR is no longer duplicated on each run

### DIFF
--- a/github-actions/update-nf-dependencies.ps1
+++ b/github-actions/update-nf-dependencies.ps1
@@ -8,7 +8,7 @@ param ($nugetReleaseType)
 
 if ([string]::IsNullOrEmpty($nugetReleaseType))
 {
-    if('${{ github.ref }}' -like '*release*' -or '${{ github.ref }}' -like '*master*' -or '${{ github.ref }}' -like '*main*' -or '${{ github.ref }}' -like '*stable*')
+    if($env:GITHUB_REF -like '*release*' -or $env:GITHUB_REF -like '*master*' -or $env:GITHUB_REF -like '*main*' -or $env:GITHUB_REF -like '*stable*')
     {
         $nugetReleaseType = "stable"
     }
@@ -56,7 +56,7 @@ else
 $updateCount = 0
 $commitMessage = ""
 $prTitle = ""
-$newBranchName = "develop-nfbot/update-dependencies/" + [guid]::NewGuid().ToString()
+$newBranchName = "develop-nfbot/update-dependencies-$env:GITHUB_HEAD_REF" #+ [guid]::NewGuid().ToString()
 $workingPath = '.\'
 
 # need this to remove definition of redirect stdErr (only on Azure Pipelines image fo VS2019)
@@ -172,11 +172,11 @@ foreach ($solutionFile in $solutionFiles)
 
                     if (![string]::IsNullOrEmpty($nugetConfig))
                     {
-                        nuget update $solutionFile.FullName -Id "$packageName" -ConfigFile $nugetConfig
+                        nuget update $solutionFile.FullName -Id "$packageName" -ConfigFile $nugetConfig -FileConflictAction Overwrite
                     }
                     else
                     {
-                        nuget update $solutionFile.FullName -Id "$packageName"
+                        nuget update $solutionFile.FullName -Id "$packageName" -FileConflictAction Overwrite
                     }
 
                 }
@@ -185,11 +185,11 @@ foreach ($solutionFile in $solutionFiles)
 
                     if (![string]::IsNullOrEmpty($nugetConfig))
                     {
-                        nuget update $solutionFile.FullName -Id "$packageName" -ConfigFile $nugetConfig -PreRelease
+                        nuget update $solutionFile.FullName -Id "$packageName" -ConfigFile $nugetConfig -PreRelease -FileConflictAction Overwrite
                     }
                     else
                     {
-                        nuget update $solutionFile.FullName -Id "$packageName" -PreRelease
+                        nuget update $solutionFile.FullName -Id "$packageName" -PreRelease -FileConflictAction Overwrite
                     }
                 }
 


### PR DESCRIPTION
## Description
Fix checks for branch names & PR is no longer duplicated on each run.
(also rolls in #29 )

## Motivation and Context
The current method for checking branch names does not seem to work in practice, also when the dependency check is run, it creates a new PR every time. This should fix that.

## How Has This Been Tested?
Fork with seperate lib.

## Screenshots

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
