### PR TITLE
Allow targeting subdirectory within a repo for nuget updates.

### DIFF
--- a/github-actions/update-nf-dependencies.ps1
+++ b/github-actions/update-nf-dependencies.ps1
@@ -5,6 +5,7 @@
 
 # optional parameter to request for stable or preview releases to be used when updating NuGets
 param ($nugetReleaseType)
+param ($targetDirectory)
 
 if ([string]::IsNullOrEmpty($nugetReleaseType))
 {
@@ -50,13 +51,23 @@ else
     "Moving to 'main' folder" | Write-Host
 
     Set-Location "main" | Out-Null
+
+    if ([string]::IsNullOrEmpty($targetDirectory))
+    {
+        Write-Host "Targeting everything in the root directory"
+    }
+    else
+    {
+        Write-Host "Targeting everything in the sub directory $targetDirectory"
+        Set-Location "$targetDirectory" | Out-Null
+    }
 }
 
 # init/reset these
 $updateCount = 0
 $commitMessage = ""
 $prTitle = ""
-$newBranchName = "develop-nfbot/update-dependencies-$env:GITHUB_HEAD_REF" #+ [guid]::NewGuid().ToString()
+$newBranchName = "develop-nfbot/update-dependencies-$env:GITHUB_REF" #+ [guid]::NewGuid().ToString()
 $workingPath = '.\'
 
 # need this to remove definition of redirect stdErr (only on Azure Pipelines image fo VS2019)


### PR DESCRIPTION
## Description
Allow targeting subdirectory within a repo for nuget updates.

## Motivation and Context
It might be advantageous to target a solution or project in a subdirectory (rather than the root) so there is not a reoccurring (chicken and egg) update.

## How Has This Been Tested?
This is a hypothetical fix. It needs testing!!!

## Screenshots

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
