### PR TITLE
Fix vs extension detection

### DIFF
--- a/github-actions/install-nf-build-components.ps1
+++ b/github-actions/install-nf-build-components.ps1
@@ -25,7 +25,7 @@ $VsInstance = $(&$VSWherePath -latest -property displayName) | Write-Host
 
 
 ###### Add new extension ID's here! ######
-if ($VsInstance[0].Contains('2017')) {
+if ($VsInstance.Contains('2017')) {
     $vsid = '47973986-ed3c-4b64-ba40-a9da73b44ef7'
 }
 else { #Presume VS2017 in all other circumstances

--- a/github-actions/install-nf-build-components.ps1
+++ b/github-actions/install-nf-build-components.ps1
@@ -25,7 +25,7 @@ $VsInstance = $(&$VSWherePath -latest -property displayName) | Write-Host
 
 
 ###### Add new extension ID's here! ######
-if ($VsInstance -like '*2017*')) {
+if ($VsInstance -like '*2017*') {
     $vsid = '47973986-ed3c-4b64-ba40-a9da73b44ef7'
 }
 else { #Presume VS2019 in all other circumstances
@@ -55,5 +55,6 @@ foreach ($entry in $feedDetails.feed.entry) {
         Copy-Item -Path "$tempDir\nf-extension\`$MSBuild\nanoFramework" -Destination $msbuildPath -Recurse
 
         Write-Host "Installed VS extension v$extensionVersion"
+        break  # exit the foreach loop
     }
 }

--- a/github-actions/install-nf-build-components.ps1
+++ b/github-actions/install-nf-build-components.ps1
@@ -25,7 +25,7 @@ $VsInstance = $(&$VSWherePath -latest -property displayName) | Write-Host
 
 
 ###### Add new extension ID's here! ######
-if ($VsInstance.Contains('2017')) {
+if ($VsInstance[0].Contains('2017')) {
     $vsid = '47973986-ed3c-4b64-ba40-a9da73b44ef7'
 }
 else { #Presume VS2017 in all other circumstances

--- a/github-actions/install-nf-build-components.ps1
+++ b/github-actions/install-nf-build-components.ps1
@@ -25,7 +25,7 @@ $VsInstance = $(&$VSWherePath -latest -property displayName) | Write-Host
 
 
 ###### Add new extension ID's here! ######
-if ($VsInstance = 'Visual Studio 2017') {
+if ($VsInstance.Contains('2017')) {
     $vsid = '47973986-ed3c-4b64-ba40-a9da73b44ef7'
 }
 else { #Presume VS2017 in all other circumstances
@@ -38,7 +38,7 @@ foreach ($entry in $feedDetails.feed.entry) {
     if ($entry.id = $vsid) {
         $extensionUrl = $entry.content.src
         $vsixPath = Join-Path -Path $tempDir -ChildPath "nf-extension.zip"
-        $extensionVersion = entry.Vsix.Version
+        $extensionVersion = $entry.Vsix.Version
     }
 }
 

--- a/github-actions/install-nf-build-components.ps1
+++ b/github-actions/install-nf-build-components.ps1
@@ -23,12 +23,25 @@ Write-Output "VsWherePath is: $VsWherePath"
 
 $VsInstance = $(&$VSWherePath -latest -property displayName) | Write-Host
 
-$idVS2019 = 0 #Should probably target the specific VISX ID or "title" since this can change over time (and will likely be needed for VS2021).
-#$idVS2017 = 1
 
-$extensionUrl = $feedDetails.feed.entry[$idVS2019].content.src
-$vsixPath = Join-Path -Path $tempDir -ChildPath "nf-extension.zip"
-$extensionVersion = $feedDetails.feed.entry[$idVS2019].Vsix.Version
+###### Add new extension ID's here! ######
+if ($VsInstance = 'Visual Studio 2017') {
+    $vsid = '47973986-ed3c-4b64-ba40-a9da73b44ef7'
+}
+else { #Presume VS2017 in all other circumstances
+    $vsid = '455f2be5-bb07-451e-b351-a9faf3018dc9'
+}
+############################################
+
+
+foreach ($entry in $feedDetails.feed.entry) {
+    if ($entry.id = $vsid) {
+        $extensionUrl = $entry.content.src
+        $vsixPath = Join-Path -Path $tempDir -ChildPath "nf-extension.zip"
+        $extensionVersion = entry.Vsix.Version
+    }
+}
+
 
 # Download VS extension
 DownloadVsixFile $extensionUrl $vsixPath

--- a/github-actions/install-nf-build-components.ps1
+++ b/github-actions/install-nf-build-components.ps1
@@ -21,10 +21,10 @@ $VsWherePath = "${env:PROGRAMFILES(X86)}\Microsoft Visual Studio\Installer\vswhe
 
 Write-Output "VsWherePath is: $VsWherePath"
 
-$VsInstance = $(&$VSWherePath -latest -property displayName)
+$VsInstance = $(&$VSWherePath -latest -property displayName) | Write-Host
 
-$idVS2019 = 1
-#$idVS2017 = 0
+$idVS2019 = 0 #Should probably target the specific VISX ID or "title" since this can change over time (and will likely be needed for VS2021).
+#$idVS2017 = 1
 
 $extensionUrl = $feedDetails.feed.entry[$idVS2019].content.src
 $vsixPath = Join-Path -Path $tempDir -ChildPath "nf-extension.zip"


### PR DESCRIPTION
## Description

## Motivation and Context
The VS extension installed when running install-nf-build-components.ps1  may not be correct if the XML entry changes. This adds better logic to ensure the correct extension is installed.

## How Has This Been Tested?<!-- (if applicable) -->
Against the repo https://github.com/networkfusion/MBN-TinyCLR/runs/2547764418?check_suite_focus=true
(although it does not cover VS2017)

## Screenshots
![image](https://user-images.githubusercontent.com/11439699/117695863-995c6480-b1b8-11eb-8d2e-db22bca8adf4.png)

![image](https://user-images.githubusercontent.com/11439699/117695958-b133e880-b1b8-11eb-8843-2d66d310c6f1.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
