### PR TITLE
Add symbols to nuget packages.

### DIFF
--- a/azure-pipelines-templates/class-lib-build.yml
+++ b/azure-pipelines-templates/class-lib-build.yml
@@ -274,7 +274,7 @@ steps:
   displayName: Pack NuGet with class library
   inputs:
     command: 'custom' 
-    arguments: 'pack $(nugetPackageName).nuspec -Version $(MY_NUGET_VERSION) -properties nativeVersion="$(ASSEMBLY_NATIVE_VERSION)";commit="$(Build.SourceVersion)";checksum="$(NATIVE_ASSEMBLY_CHECKSUM)"'
+    arguments: 'pack $(nugetPackageName).nuspec -Version $(MY_NUGET_VERSION) -Symbols -SymbolPackageFormat snupkg -properties nativeVersion="$(ASSEMBLY_NATIVE_VERSION)";commit="$(Build.SourceVersion)";checksum="$(NATIVE_ASSEMBLY_CHECKSUM)"'
 
 # - task: NuGetCommand@2
 #   inputs:

--- a/azure-pipelines-templates/class-lib-package.yml
+++ b/azure-pipelines-templates/class-lib-package.yml
@@ -12,7 +12,7 @@ steps:
   displayName: Pack NuGet with class library
   inputs:
     command: 'custom' 
-    arguments: 'pack ${{ parameters.nugetPackageName }}.nuspec -Version $(MY_NUGET_VERSION) -properties nativeVersion="$(ASSEMBLY_NATIVE_VERSION)";commit="$(Build.SourceVersion)";checksum="$(NATIVE_ASSEMBLY_CHECKSUM)"'
+    arguments: 'pack ${{ parameters.nugetPackageName }}.nuspec -Version $(MY_NUGET_VERSION) -Symbols -SymbolPackageFormat snupkg -properties nativeVersion="$(ASSEMBLY_NATIVE_VERSION)";commit="$(Build.SourceVersion)";checksum="$(NATIVE_ASSEMBLY_CHECKSUM)"'
 
 - task: CopyFiles@1
   condition: and( succeeded(), ne( variables['StartReleaseCandidate'], true ) )


### PR DESCRIPTION
## Description

## Motivation and Context
Symbol packages are not currently published to nuget. This can cause issues when trying to debug a local program.
It works when I use it within a GitHub workflow, see https://github.com/networkfusion/MBN-TinyCLR/blob/develop-nanoframework/.github/workflows/build.yml for reference.

## How Has This Been Tested?
Should be tested on a single (and possibily new or deprecated) lib first, incase it does not work as intended?

## Screenshots<!-- (if appropriate): -->

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
