### PR TITLE
Add .snupkg artifact to ArtifactStagingDirectory

### DIFF
--- a/azure-pipelines-templates/class-lib-build.yml
+++ b/azure-pipelines-templates/class-lib-build.yml
@@ -289,6 +289,7 @@ steps:
     sourceFolder: $(Build.SourcesDirectory)
     Contents: |
       $(nugetPackageName)*.nupkg
+      $(nugetPackageName)*.snupkg
       CHANGELOG.md
     TargetFolder: '$(Build.ArtifactStagingDirectory)'
     flattenFolders: true


### PR DESCRIPTION
## Description

## Motivation and Context
The `.snupkg` package was created, but not moved to the staging directory, so would not be available for upload.

## How Has This Been Tested?
Requires a manual build as an extension of #34 .

## Screenshots

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
