### PR TITLE
[Profiler] Non-blocking UI while Adding Device

### DIFF
--- a/tools/Profiler/NanoProfiler/ViewModels/ProfilerLauncherViewModel.cs
+++ b/tools/Profiler/NanoProfiler/ViewModels/ProfilerLauncherViewModel.cs
@@ -10,7 +10,6 @@ using nanoFramework.Tools.Debugger;
 using nanoFramework.Tools.Debugger.Extensions;
 using nanoFramework.Tools.Debugger.WireProtocol;
 using nanoFramework.Tools.NanoProfiler.Helpers;
-using Polly;
 using System;
 using System.IO;
 using System.Linq;
@@ -18,7 +17,6 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Windows.Media;
 using System.Windows.Threading;
-using static System.Net.Mime.MediaTypeNames;
 using _DBG = nanoFramework.Tools.Debugger;
 using _PRF = nanoFramework.Tools.NanoProfiler;
 using _WP = nanoFramework.Tools.Debugger.WireProtocol;
@@ -221,7 +219,6 @@ namespace nanoFramework.Tools.NanoProfiler.ViewModels
 
         #endregion
 
-
         #region Constructor
         public ProfilerLauncherViewModel()
         {
@@ -406,26 +403,26 @@ namespace nanoFramework.Tools.NanoProfiler.ViewModels
             SoftDisconnect();
         }
 
-        public Task<bool> Connect()
+        public async Task<bool> Connect()
         {
             // string outputFileName = $"E:\\temp\\nano\\profile-{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}.log";
 
             // connect to specified serial port
             try
             {
-                _serialDebuggerPort.AddDevice(ComPortName);
+                await Task.Run(()=>   _serialDebuggerPort.AddDevice(ComPortName));
             }
 #if DEBUG
             catch (Exception ex)
             {
                 Console.WriteLine($"Failed to add device: {ex.Message}");
 
-                return Task.FromResult(false);
+                return false;
             }
 #else
             catch
             {
-                return Task.FromResult(false);
+                return false;
 
             }
 #endif
@@ -478,7 +475,7 @@ namespace nanoFramework.Tools.NanoProfiler.ViewModels
                         {
                             Disconnect();
 
-                            return Task.FromResult(false);
+                            return false;
                         }
 
                     checInitState:
@@ -529,13 +526,13 @@ namespace nanoFramework.Tools.NanoProfiler.ViewModels
                             }
 
                             // done here
-                            return Task.FromResult(true);
+                            return true;
                         }
                     }
                 }
             }
 
-            return Task.FromResult(false);
+            return false;
         }
 
         private void CheckOutpuFileName()

--- a/tools/Profiler/NanoProfiler/ViewModels/ProfilerLauncherViewModel.cs
+++ b/tools/Profiler/NanoProfiler/ViewModels/ProfilerLauncherViewModel.cs
@@ -410,7 +410,7 @@ namespace nanoFramework.Tools.NanoProfiler.ViewModels
             // connect to specified serial port
             try
             {
-                await Task.Run(()=>   _serialDebuggerPort.AddDevice(ComPortName));
+                await Task.Run(() =>  _serialDebuggerPort.AddDevice(ComPortName));
             }
 #if DEBUG
             catch (Exception ex)


### PR DESCRIPTION
## Description
Better usage of Async await pattern by adding device

## Motivation and Context
Improve handling Windows while long process is doing

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Start Profiler
Press connect Button
Move Window by drap& drop 
Expected: window should move properly

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
