### PR TITLE
Remove the Private element from Reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ AzureDevOps/TaskInstallMSBuildComponents/node_modules
 AzureDevOps/TaskUpdateNativeAssemblyDeclaration/node_modules
 *launchSettings.json
 **/Properties/launchSettings.json
+
+# JetBrains Rider
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ AzureDevOps/TaskUpdateNativeAssemblyDeclaration/node_modules
 
 # JetBrains Rider
 .idea/
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ AzureDevOps/TaskUpdateNativeAssemblyDeclaration/node_modules
 
 # JetBrains Rider
 .idea/
-

--- a/tools/DependencyUpdater/Program.cs
+++ b/tools/DependencyUpdater/Program.cs
@@ -817,7 +817,24 @@ namespace nanoFramework.Tools.DependencyUpdater
 
                                     File.WriteAllText(projectToUpdate, updatedProjContent);
                                 }
+            
+                                // Remove the <Private> elements NuGet adds to the project file
+                                // This could be async be the tool isn't using that so I'll skip it for now
+                                var projectDocument = XDocument.Load(projectToUpdate);
+                                var referenceElements = projectDocument.Root?.Descendants().Where(x => x.Name.LocalName == "Reference").ToList();
+                                
+                                foreach (var referenceElement in referenceElements)
+                                {
+                                    var privateElements = referenceElement.Descendants().Where(x => x.Name.LocalName == "Private").ToList();
+                                    foreach (var privateElement in privateElements)
+                                    {
+                                        privateElement.Remove();
+                                    }
+                                }
 
+                                using var projectFile = File.Create(projectToUpdate);
+                                projectDocument.Save(projectFile, SaveOptions.None);
+                                
                                 // load nuspec file content, if there is a nuspec file to update
                                 if (nuspecFileName is not null)
                                 {


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Remove the Reference/Private elements from the updated project file.

## Motivation and Context
I'm frustrated having to manually adjust all the broken references when I open a project from a clean source

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Manually: https://github.com/CCSWE-nanoFramework/CCSWE.nanoFramework.NeoPixel/pull/52

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [X] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
