### PR TITLE
[nanodu] Only save the project file if a change has been made

### DIFF
--- a/tools/DependencyUpdater/Program.cs
+++ b/tools/DependencyUpdater/Program.cs
@@ -820,6 +820,7 @@ namespace nanoFramework.Tools.DependencyUpdater
             
                                 // Remove the <Private> elements NuGet adds to the project file
                                 // This could be async be the tool isn't using that so I'll skip it for now
+                                var privateElementsRemoved = false;
                                 var projectDocument = XDocument.Load(projectToUpdate);
                                 var referenceElements = projectDocument.Root?.Descendants().Where(x => x.Name.LocalName == "Reference").ToList();
                                 
@@ -828,12 +829,16 @@ namespace nanoFramework.Tools.DependencyUpdater
                                     var privateElements = referenceElement.Descendants().Where(x => x.Name.LocalName == "Private").ToList();
                                     foreach (var privateElement in privateElements)
                                     {
+                                        privateElementsRemoved = true;
                                         privateElement.Remove();
                                     }
                                 }
 
-                                using var projectFile = File.Create(projectToUpdate);
-                                projectDocument.Save(projectFile, SaveOptions.None);
+                                if (privateElementsRemoved)
+                                {
+                                    using var projectFile = File.Create(projectToUpdate);
+                                    projectDocument.Save(projectFile, SaveOptions.None);
+                                }
                                 
                                 // load nuspec file content, if there is a nuspec file to update
                                 if (nuspecFileName is not null)

--- a/tools/DependencyUpdater/Program.cs
+++ b/tools/DependencyUpdater/Program.cs
@@ -805,19 +805,19 @@ namespace nanoFramework.Tools.DependencyUpdater
                                     }
 
                                     Console.WriteLine($"Bumping {packageName} from {packageOriginVersion} to {packageTargetVersion}.");
+                                    
+                                    // if this is the Test Framework, need to update the nfproj file too
+                                    if (packageName == "nanoFramework.TestFramework")
+                                    {
+                                        // read nfproj file
+                                        var nfprojFileContent = File.ReadAllText(projectToUpdate);
+
+                                        var updatedProjContent = Regex.Replace(nfprojFileContent, $"(?<=packages\\\\nanoFramework\\.TestFramework\\.)(?'version'\\d+\\.\\d+\\.\\d+)(?=\\\\build\\\\)", packageTargetVersion, RegexOptions.ExplicitCapture);
+
+                                        File.WriteAllText(projectToUpdate, updatedProjContent);
+                                    }
                                 }
-
-                                // if this is the Test Framework, need to update the nfproj file too
-                                if (packageName == "nanoFramework.TestFramework")
-                                {
-                                    // read nfproj file
-                                    var nfprojFileContent = File.ReadAllText(projectToUpdate);
-
-                                    var updatedProjContent = Regex.Replace(nfprojFileContent, $"(?<=packages\\\\nanoFramework\\.TestFramework\\.)(?'version'\\d+\\.\\d+\\.\\d+)(?=\\\\build\\\\)", packageTargetVersion, RegexOptions.ExplicitCapture);
-
-                                    File.WriteAllText(projectToUpdate, updatedProjContent);
-                                }
-            
+                                
                                 // Remove the <Private> elements NuGet adds to the project file
                                 // This could be async be the tool isn't using that so I'll skip it for now
                                 var privateElementsRemoved = false;

--- a/tools/DependencyUpdater/Program.cs
+++ b/tools/DependencyUpdater/Program.cs
@@ -817,7 +817,7 @@ namespace nanoFramework.Tools.DependencyUpdater
                                         File.WriteAllText(projectToUpdate, updatedProjContent);
                                     }
                                 }
-                                
+
                                 // Remove the <Private> elements NuGet adds to the project file
                                 // This could be async be the tool isn't using that so I'll skip it for now
                                 var privateElementsRemoved = false;


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Add a check to only save the nfproj if a private element was removed
- Move the special TestFramework case to only occur when the library is updated

## Motivation and Context
When I ran the latest version I noticed several project files were updated that did not have dependency updates associated with them (see this [commit](https://github.com/CCSWE-nanoFramework/CCSWE.nanoFramework.NeoPixel/commit/08ef74c3d05b1993d8451d014c8e3cbc3023b872#diff-537c48e1e40ebfdc62272822fb9b0efa7c0d3d2108b85090885d751671c77dd6R1)). The changes were whitespace and it doesn't cause any issues but I felt it was better if the tool only made changes to the nfproj if a dependency was updated.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Manually: https://github.com/CCSWE-nanoFramework/CCSWE.nanoFramework.NeoPixel/pull/56

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
