### PR TITLE
Remove the user check when looking for duplicate PRs

### DIFF
--- a/tools/DependencyUpdater/Program.cs
+++ b/tools/DependencyUpdater/Program.cs
@@ -1124,9 +1124,9 @@ namespace nanoFramework.Tools.DependencyUpdater
                 // check if there is already a PR with these updates
                 var openPRs = _octokitClient.PullRequest.GetAllForRepository(repoOwner, libraryName, new PullRequestRequest() { State = ItemStateFilter.Open }).Result;
 
-                var updatePRs = openPRs.Where(pr => pr.Title == prTitle && pr.Body == commitMessage).ToList();
+                var updatePRs = openPRs.Where(pr => pr.Title == prTitle && pr.Body == commitMessage);
 
-                if (updatePRs.Count != 0)
+                if (updatePRs.Any())
                 {
                     Console.WriteLine($"INFO: found existing PR with the same update: {repoOwner}/{libraryName}/pull/{updatePRs.First().Number}. Skipping PR creation.");
 

--- a/tools/DependencyUpdater/Program.cs
+++ b/tools/DependencyUpdater/Program.cs
@@ -1124,9 +1124,9 @@ namespace nanoFramework.Tools.DependencyUpdater
                 // check if there is already a PR with these updates
                 var openPRs = _octokitClient.PullRequest.GetAllForRepository(repoOwner, libraryName, new PullRequestRequest() { State = ItemStateFilter.Open }).Result;
 
-                var updatePRs = openPRs.Where(pr => pr.User.Login == _gitHubUser && pr.Title == prTitle && pr.Body == commitMessage);
+                var updatePRs = openPRs.Where(pr => pr.Title == prTitle && pr.Body == commitMessage).ToList();
 
-                if (updatePRs.Any())
+                if (updatePRs.Count != 0)
                 {
                     Console.WriteLine($"INFO: found existing PR with the same update: {repoOwner}/{libraryName}/pull/{updatePRs.First().Number}. Skipping PR creation.");
 


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Remove the user check when looking for duplicate PRs

## Motivation and Context
When I use this tool in my own GitHub actions the user that is authenticated does not match the user that gets attributed to the PR.

An example of this can be seen in these two PRs:

https://github.com/CCSWE-nanoFramework/CCSWE.nanoFramework/pull/53
https://github.com/CCSWE-nanoFramework/CCSWE.nanoFramework/pull/52

The default value of "nfbot" has been passed for the gitHubUser parameter but the PR that is created is attributed to the "github-actions" user.

I started by trying to determine how to resolve this difference but came to the conclusion that if both the title and body of the open PR are identical then it likely doesn't matter who created it.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Locally

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
