### PR TITLE
[github actions template] Pin vmImage to 2022

### DIFF
--- a/.github/workflows/NanoFramework-GitHubBot.yml
+++ b/.github/workflows/NanoFramework-GitHubBot.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: windows-latest
+    runs-on: windows-2022
     
     steps:
     - name: 'Checkout GitHub Action'

--- a/.github/workflows/check-package-lock.yml
+++ b/.github/workflows/check-package-lock.yml
@@ -18,7 +18,7 @@ jobs:
   check_package_lock_file:
     name: package.lock exists
     timeout-minutes: 5
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Checkout

--- a/.github/workflows/check-packages-updated.yml
+++ b/.github/workflows/check-packages-updated.yml
@@ -17,7 +17,7 @@ jobs:
   check_nugets_using_latest_version:
     name: NuGets using latest version
     timeout-minutes: 15
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       GITHUB_AUTH_TOKEN: ${{ secrets.NANOBUILD_PAT }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -44,7 +44,7 @@ jobs:
   update-nanoframework-nugets:
     name: Update .NET nanoFramework NuGet packages
     timeout-minutes: ${{ inputs.timeout-minutes }}
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       GITHUB_TOKEN: ${{ github.token }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
 ##############################
 - job: Check_Build_Options
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2022'
 
   steps:
   
@@ -108,7 +108,7 @@ jobs:
     Check_Build_Options
 
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2022'
 
   variables:
     - group: sign-client-credentials
@@ -227,7 +227,7 @@ jobs:
     Check_Build_Options
 
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2022'
 
   variables:
     - group: sign-client-credentials
@@ -371,7 +371,7 @@ jobs:
     Check_Build_Options
 
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2022'
 
   variables:
     - group: sign-client-credentials
@@ -421,7 +421,7 @@ jobs:
     )
 
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2022'
 
   steps:
 


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Pin vmImage used for CI jobs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
A change for windows-latest from Windows 2022 to Windows 2025 is imminent. Rather than winging it, we should pin to the working version, and test before we suffer the consequences.

Reasons:
- pleanty of time before the 2022 image is deprecated.
- pinning a version will make it less likely to break.
- already getting warnings in the CI which report failure.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated all CI runners to Windows Server 2022 across GitHub Actions workflows and Azure Pipelines, aligning build environments for improved stability and consistency.
  - No changes to job logic, steps, or artifacts; builds and checks continue to run as before.
  - Future-proofs the pipeline against deprecations of older runner images and reduces variability between environments.
  - No user-facing functionality changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->