### PR TITLE
Add slnx support in nanovc

### DIFF
--- a/tools/VersionCop/Program.cs
+++ b/tools/VersionCop/Program.cs
@@ -95,7 +95,8 @@ class Program
         }
 
         // handle mscorlib library
-        if (solutionToCheck.EndsWith("nanoFramework.CoreLibrary.sln"))
+        if (solutionToCheck.EndsWith("nanoFramework.CoreLibrary.sln") ||
+            solutionToCheck.EndsWith("nanoFramework.CoreLibrary.slnx"))
         {
             Console.WriteLine("ℹ️  This is mscorlib, skipping this check!");
             return 0;
@@ -140,6 +141,7 @@ class Program
 
         // read solution file content
         var slnFileContent = File.ReadAllText(solutionToCheck);
+        bool isSlnx = solutionToCheck.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase);
 
         // find ALL packages.config files in the solution projects
         var packageConfigs = Directory.GetFiles(workingDirectory, "packages.config", SearchOption.AllDirectories);
@@ -190,32 +192,65 @@ class Program
             Console.WriteLine();
             WriteGroupStart($"📂 Project: {Path.GetFileName(Path.GetDirectoryName(packageConfigFile))}");
 
-            var projectPathInSln = Path.GetRelativePath(workingDirectory, Directory.GetParent(packageConfigFile).FullName);
+            var packageConfigRelPath = Path.GetRelativePath(workingDirectory, Directory.GetParent(packageConfigFile).FullName);
 
-            // check for project in the same folder
-            if (projectPathInSln == ".")
+            string projectToCheck;
+            string projectName;
+
+            if (isSlnx)
             {
-                projectPathInSln = "";
+                // slnx is XML-based: <Project Path="folder\Project.nfproj" /> or <Project Path="Project.nfproj" />
+                var slnxDoc = XDocument.Parse(slnFileContent);
+                var projectEl = slnxDoc.Descendants("Project")
+                    .FirstOrDefault(el =>
+                    {
+                        var path = el.Attribute("Path")?.Value;
+                        if (path == null) return false;
+                        var dir = Path.GetDirectoryName(path) ?? string.Empty;
+                        
+                        // Normalize directory separators
+                        dir = dir.Replace('/', '\\');
+                        var normalizedRelPath = packageConfigRelPath.Replace('/', '\\');
+                        
+                        // Handle root-level projects (empty directory or ".")
+                        if (string.IsNullOrEmpty(dir))
+                        {
+                            return normalizedRelPath == "." || string.IsNullOrEmpty(normalizedRelPath);
+                        }
+                        
+                        return string.Equals(dir, normalizedRelPath, StringComparison.OrdinalIgnoreCase);
+                    });
+
+                if (projectEl == null)
+                {
+                    Console.WriteLine($"  ⚠️  Couldn't find a project matching this packages.config - skipping");
+                    WriteGroupEnd();
+                    continue;
+                }
+
+                var projectPath = projectEl.Attribute("Path").Value;
+                projectName = Path.GetFileNameWithoutExtension(projectPath);
+                projectToCheck = Directory.GetFiles(workingDirectory, Path.GetFileName(projectPath), SearchOption.AllDirectories).FirstOrDefault();
             }
             else
             {
-                // need these extra replacements to adjust for regex expression
-                projectPathInSln = projectPathInSln.Replace("\\", "\\\\")
-                                                     .Replace(".", "\\.")
-                                                     + "\\\\"; // add trailing \ to match whatever will be in the solution file
-            }
+                var projectPathInSln = packageConfigRelPath == "."
+                    ? ""
+                    : packageConfigRelPath.Replace("\\", "\\\\")
+                                         .Replace(".", "\\.")
+                                         + "\\\\"; // add trailing \ to match whatever will be in the solution file
 
-            var match = Regex.Match(slnFileContent, $"(?> = \\\")(?'projectname'[a-zA-Z0-9_.-]+)(?>\\\", \\\"{projectPathInSln})(?'projectpath'[a-zA-Z0-9_.-]+.nfproj)(\\\")");
-            if (!match.Success)
-            {
-                Console.WriteLine($"  ⚠️  Couldn't find a project matching this packages.config - skipping");
-                WriteGroupEnd();
-                continue;
-            }
+                var match = Regex.Match(slnFileContent, $"(?> = \\\")(?'projectname'[a-zA-Z0-9_.-]+)(?>\\\", \\\"{projectPathInSln})(?'projectpath'[a-zA-Z0-9_.-]+.nfproj)(\\\")");
+                if (!match.Success)
+                {
+                    Console.WriteLine($"  ⚠️  Couldn't find a project matching this packages.config - skipping");
+                    WriteGroupEnd();
+                    continue;
+                }
 
-            // compose project path
-            var projectToCheck = Directory.GetFiles(workingDirectory, match.Groups["projectpath"].Value, SearchOption.AllDirectories).FirstOrDefault();
-            var projectName = match.Groups["projectname"].Value;
+                projectToCheck = Directory.GetFiles(workingDirectory, match.Groups["projectpath"].Value, SearchOption.AllDirectories).FirstOrDefault();
+                projectName = match.Groups["projectname"].Value;
+            }
 
             Console.WriteLine($"  📄 {Path.GetFileNameWithoutExtension(projectToCheck)}");
 

--- a/tools/VersionCop/Program.cs
+++ b/tools/VersionCop/Program.cs
@@ -240,6 +240,15 @@ class Program
                 projectPath = projectPath.Replace('\\', Path.DirectorySeparatorChar);
                 // Construct full path directly from working directory + relative path in slnx
                 projectToCheck = Path.Combine(workingDirectory, projectPath);
+                
+                // Check if the project file actually exists on disk
+                if (!File.Exists(projectToCheck))
+                {
+                    Console.WriteLine($"  ⚠️  Project file not found: {projectToCheck} - skipping");
+                    WriteGroupEnd();
+                    continue;
+                }
+                
                 projectName = Path.GetFileNameWithoutExtension(projectPath);
             }
             else

--- a/tools/VersionCop/Program.cs
+++ b/tools/VersionCop/Program.cs
@@ -95,8 +95,8 @@ class Program
         }
 
         // handle mscorlib library
-        if (solutionToCheck.EndsWith("nanoFramework.CoreLibrary.sln") ||
-            solutionToCheck.EndsWith("nanoFramework.CoreLibrary.slnx"))
+        if (solutionToCheck.EndsWith("nanoFramework.CoreLibrary.sln", StringComparison.OrdinalIgnoreCase) ||
+            solutionToCheck.EndsWith("nanoFramework.CoreLibrary.slnx", StringComparison.OrdinalIgnoreCase))
         {
             Console.WriteLine("ℹ️  This is mscorlib, skipping this check!");
             return 0;
@@ -187,6 +187,13 @@ class Program
         // Use a generic .NET target framework for cache building
         BuildPackageCache(packageConfigs, NuGet.Frameworks.NuGetFramework.AnyFramework);
 
+        // Parse slnx document once if needed (avoids repeated parsing for each package.config)
+        XDocument slnxDoc = null;
+        if (isSlnx)
+        {
+            slnxDoc = XDocument.Parse(slnFileContent);
+        }
+
         foreach (var packageConfigFile in packageConfigs)
         {
             Console.WriteLine();
@@ -200,17 +207,17 @@ class Program
             if (isSlnx)
             {
                 // slnx is XML-based: <Project Path="folder\Project.nfproj" /> or <Project Path="Project.nfproj" />
-                var slnxDoc = XDocument.Parse(slnFileContent);
-                var projectEl = slnxDoc.Descendants("Project")
+                var projectElement = slnxDoc.Descendants("Project")
                     .FirstOrDefault(el =>
                     {
                         var path = el.Attribute("Path")?.Value;
                         if (path == null) return false;
-                        var dir = Path.GetDirectoryName(path) ?? string.Empty;
                         
-                        // Normalize directory separators
-                        dir = dir.Replace('/', '\\');
-                        var normalizedRelPath = packageConfigRelPath.Replace('/', '\\');
+                        // Normalize separators BEFORE parsing so it works cross-platform
+                        // (Path.GetDirectoryName won't recognize \ on non-Windows OSes)
+                        path = path.Replace('\\', Path.DirectorySeparatorChar);
+                        var dir = Path.GetDirectoryName(path) ?? string.Empty;
+                        var normalizedRelPath = packageConfigRelPath.Replace('/', '\\').Replace('\\', Path.DirectorySeparatorChar);
                         
                         // Handle root-level projects (empty directory or ".")
                         if (string.IsNullOrEmpty(dir))
@@ -221,16 +228,19 @@ class Program
                         return string.Equals(dir, normalizedRelPath, StringComparison.OrdinalIgnoreCase);
                     });
 
-                if (projectEl == null)
+                if (projectElement == null)
                 {
                     Console.WriteLine($"  ⚠️  Couldn't find a project matching this packages.config - skipping");
                     WriteGroupEnd();
                     continue;
                 }
 
-                var projectPath = projectEl.Attribute("Path").Value;
+                var projectPath = projectElement.Attribute("Path").Value;
+                // Normalize separators to match the current OS
+                projectPath = projectPath.Replace('\\', Path.DirectorySeparatorChar);
+                // Construct full path directly from working directory + relative path in slnx
+                projectToCheck = Path.Combine(workingDirectory, projectPath);
                 projectName = Path.GetFileNameWithoutExtension(projectPath);
-                projectToCheck = Directory.GetFiles(workingDirectory, Path.GetFileName(projectPath), SearchOption.AllDirectories).FirstOrDefault();
             }
             else
             {
@@ -250,6 +260,14 @@ class Program
 
                 projectToCheck = Directory.GetFiles(workingDirectory, match.Groups["projectpath"].Value, SearchOption.AllDirectories).FirstOrDefault();
                 projectName = match.Groups["projectname"].Value;
+            }
+
+            // Guard against null projectToCheck (file not found on disk)
+            if (projectToCheck is null)
+            {
+                Console.WriteLine($"  ⚠️  Couldn't resolve project file on disk - skipping");
+                WriteGroupEnd();
+                continue;
             }
 
             Console.WriteLine($"  📄 {Path.GetFileNameWithoutExtension(projectToCheck)}");

--- a/tools/VersionCop/Program.cs
+++ b/tools/VersionCop/Program.cs
@@ -211,7 +211,10 @@ class Program
                     .FirstOrDefault(el =>
                     {
                         var path = el.Attribute("Path")?.Value;
-                        if (path == null) return false;
+                        if (path == null)
+                        {
+                            return false;
+                        }
                         
                         // Normalize separators BEFORE parsing so it works cross-platform
                         // (Path.GetDirectoryName won't recognize \ on non-Windows OSes)


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Add slnx support in nanovc

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Add slnx support in nanovc as the format is the default one now

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a real project (the Home Assistant one from IoT Device)

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
